### PR TITLE
fix: Camera USB stack crash after second capture

### DIFF
--- a/Photobox/GPhoto2/Source/GPhoto2Camera.cpp
+++ b/Photobox/GPhoto2/Source/GPhoto2Camera.cpp
@@ -77,6 +77,10 @@ exec::task<void> GPhoto2Camera::asyncCaptureLoop()
                                  Q_EMIT imageCaptured(image.value());
                              }
                              return image.has_value();
+                         }) //
+                       | stdexec::continues_on(scheduler_->getWorkScheduler()) //
+                       | stdexec::then([this, &context](auto hasValue) {
+                            return GPhoto2::readUntilTimeout(*context);
                          })                           //
                        | exec::repeat_effect_until(); // todo: this now retries forever to capture a image.
                                                       // maybe retry_n times and emit an error?

--- a/Photobox/GPhoto2/Source/GPhoto2Integration.cpp
+++ b/Photobox/GPhoto2/Source/GPhoto2Integration.cpp
@@ -109,17 +109,49 @@ std::optional<QImage> captureImage(Context &context)
         gp_camera_capture(context.camera.get(), GP_CAPTURE_IMAGE, &camera_file_path, context.context.get());
     if (ret_val < GP_OK)
     {
-        LOG_ERROR(logger_gphoto2(), "could invoke gphoto2 capture");
+        LOG_ERROR(logger_gphoto2(), "could not invoke gphoto2 capture: {}", ret_val);
         return std::nullopt;
     }
-    gp_camera_file_get(context.camera.get(),
-                       camera_file_path.folder,
-                       camera_file_path.name,
-                       GP_FILE_TYPE_NORMAL,
-                       file.get(),
-                       context.context.get());
+    LOG_INFO(logger_gphoto2(), "captured image to {}", camera_file_path.name);
 
-    return readImageFromFile(file.get());
+    const auto file_get_ret_val = gp_camera_file_get(context.camera.get(),
+                                                     camera_file_path.folder,
+                                                     camera_file_path.name,
+                                                     GP_FILE_TYPE_NORMAL,
+                                                     file.get(),
+                                                     context.context.get());
+    if (file_get_ret_val < GP_OK)
+    {
+        LOG_ERROR(logger_gphoto2(), "could not get file: {}", file_get_ret_val);
+    }
+
+    auto image = readImageFromFile(file.get());
+
+    return image;
+}
+bool readUntilTimeout(Context &context)
+{
+    while (true)
+    {
+        CameraEventType evtype;
+        void *data = nullptr;
+
+        const int ret = gp_camera_wait_for_event(context.camera.get(), 100, &evtype, &data, context.context.get());
+
+        if (ret < GP_OK)
+        {
+            LOG_ERROR(logger_gphoto2(), "could not wait for event: {}", ret);
+            break;
+        }
+
+        if (evtype == GP_EVENT_TIMEOUT)
+        {
+            LOG_DEBUG(logger_gphoto2(), "got timeout event");
+            return true;
+        }
+    }
+
+    return false;
 }
 
 namespace

--- a/Photobox/GPhoto2/Source/GPhoto2Integration.hpp
+++ b/Photobox/GPhoto2/Source/GPhoto2Integration.hpp
@@ -15,4 +15,6 @@ bool autodetectAndConnectCamera(Context &context);
 std::optional<QImage> capturePreviewImage(Context &context);
 
 std::optional<QImage> captureImage(Context &context);
+
+bool readUntilTimeout(Context &context);
 } // namespace Pbox::GPhoto2


### PR DESCRIPTION
I am using the Sony Alpha 7s. 
I experienced an issue when taking a picture. `gp_camera_capture` returned `GP_ERROR_IO` when taking the second picture (after start of the app). Retrying will then return `GP_ERROR_IO_USB_FIND`. The photobox app now hangs in a loop right here.

```cpp
                       | exec::repeat_effect_until(); // todo: this now retries forever to capture a image.
                                                      // maybe retry_n times and emit an error?
```

In the mean time, the camera will disappear from the USB devices. I guess the USB stack in the camera errored out. 

The camera does not recover unless restarted.

After fiddling around, i noticed that nothing calls `gp_camera_wait_for_event`. So I had a feeling that the camera had some pending events it wanted to process before taking another picture. Calling `gp_camera_wait_for_event` until `GP_EVENT_TIMEOUT` occurs does fix it.

The way I implemented it should wait for the event while the captured image is shown. So no preview frames are lost and no further delay should occur. Right now, 6 events occur before timeout (1x file added, 2x capture complete, 3x unknown).

Due to not having more cameras, I can only test it with the Alpha 7s, which works fine.

Open for discussion on how to integrate that properly. I've never worked with stdexec before.