### PR TITLE
refactor(core): Split CaptureManager into different controllers 

### DIFF
--- a/Photobox/Core/CMakeLists.txt
+++ b/Photobox/Core/CMakeLists.txt
@@ -38,6 +38,14 @@ qt_add_qml_module(
         IdleCaptureSession.cpp
         CaptureManager.hpp
         CaptureManager.cpp
+        CapturePipeline.hpp
+        CapturePipeline.cpp
+        CaptureSessionCoordinator.hpp
+        CaptureSessionCoordinator.cpp
+        TriggerController.hpp
+        TriggerController.cpp
+        SessionEffectController.hpp
+        SessionEffectController.cpp
         SystemStatusCode.hpp
         SystemStatusManager.hpp
         SystemStatusManager.cpp

--- a/Photobox/Core/CaptureManager.cpp
+++ b/Photobox/Core/CaptureManager.cpp
@@ -1,16 +1,16 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Mathis Logemann <mathis.opensource@tuta.io>
+// SPDX-FileCopyrightText: 2024 - 2026 Mathis Logemann <mathis.opensource@tuta.io>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "CaptureManager.hpp"
 #include <ICamera.hpp>
-#include <Pbox/CleanupAsyncScope.hpp>
 #include <Pbox/Logger.hpp>
-#include <Scheduler.hpp>
 #include "CameraLed.hpp"
-#include "IdleCaptureSession.hpp"
+#include "CapturePipeline.hpp"
+#include "CaptureSessionCoordinator.hpp"
 #include "ImageProvider.hpp"
-#include "ImageStorage.hpp"
+#include "SessionEffectController.hpp"
+#include "TriggerController.hpp"
 
 DEFINE_LOGGER(capture_manager);
 
@@ -22,68 +22,56 @@ CaptureManager::CaptureManager(Instance<Scheduler> scheduler,
                                Instance<TriggerManager> trigger_manager,
                                Instance<CameraLed> camera_led,
                                Instance<CaptureSessionManager> capture_session_manager)
-    : scheduler_{std::move(scheduler)}
-    , image_storage_{std::move(image_storage)}
-    , camera_{std::move(camera)}
-    , trigger_manager_{std::move(trigger_manager)}
-    , camera_led_{std::move(camera_led)}
-    , session_{make_unique_object_ptr_as<ICaptureSession, IdleCaptureSession>()}
-    , capture_session_manager_{std::move(capture_session_manager)}
+    : camera_{std::move(camera)}
 {
-    connect(camera_.get(), &ICamera::imageCaptured, this, [this](auto &&image) {
-        //! important: first emit the signal so that all image providers have it saved, and only then set the image to
-        //! the session. otherwise qml will not reevaluate the image and the providers don't have a signal to schedule a
-        //! cache invalidation
-        const auto image_id = image_ids_++;
-        Q_EMIT imageCaptured(image, image_id);
-        session_->imageCaptured(image, image_id);
-        async_scope_.spawn(stdexec::schedule(scheduler_->getWorkScheduler()) |
-                           stdexec::then([this, image = image]() { return image_storage_->saveImage(image); }) |
-                           stdexec::continues_on(scheduler_->getQtEventLoopScheduler()) |
-                           stdexec::then([this](auto &&saved_image_path) { session_->imageSaved(saved_image_path); }) |
-                           stdexec::upon_error([](auto &&ex_ptr) {
-                               try
-                               {
-                                   std::rethrow_exception(ex_ptr);
-                               }
-                               catch (const std::exception &ex)
-                               {
-                                   LOG_ERROR(logger_capture_manager(), "Error while saving image. {}", ex.what());
-                               }
-                           }));
+    session_coordinator_ = std::make_unique<CaptureSessionCoordinator>(camera_, capture_session_manager);
+
+    trigger_controller_ = std::make_unique<TriggerController>(
+        trigger_manager,
+        capture_session_manager,
+        [this]() { return session_coordinator_->getSession(); },
+        [this](CaptureSessionPtr session) { session_coordinator_->switchToSession(std::move(session)); });
+
+    session_effect_controller_ = std::make_unique<SessionEffectController>(
+        trigger_manager, camera_led, [this]() -> const TriggerId & { return trigger_controller_->getTriggeredBy(); });
+
+    capture_pipeline_ = std::make_unique<CapturePipeline>(
+        scheduler, image_storage, [this]() { return session_coordinator_->getSession(); });
+
+    connect(camera_.get(), &ICamera::imageCaptured, capture_pipeline_.get(), &CapturePipeline::onCameraImageCaptured);
+    connect(capture_pipeline_.get(),
+            &CapturePipeline::imageCaptured,
+            this,
+            [this](const QImage &image, std::uint32_t image_id) { Q_EMIT imageCaptured(image, image_id); });
+    connect(session_coordinator_.get(), &CaptureSessionCoordinator::finished, this, &CaptureManager::sessionFinished);
+    connect(
+        session_coordinator_.get(), &CaptureSessionCoordinator::sessionChanged, this, &CaptureManager::sessionChanged);
+    connect(session_coordinator_.get(), &CaptureSessionCoordinator::statusChanged, this, [this]() {
+        if (auto *session = session_coordinator_->getSession())
+        {
+            session_effect_controller_->handleSessionStatusChanged(session->getStatus());
+        }
     });
-    connect(trigger_manager_.get(), &TriggerManager::triggerFired, this, [this](const TriggerId &trigger_id) {
-        triggerButtonPressed(QString::fromStdString(trigger_id));
+    connect(session_coordinator_.get(), &CaptureSessionCoordinator::captureStatusChanged, this, [this]() {
+        if (auto *session = session_coordinator_->getSession())
+        {
+            session_effect_controller_->handleSessionCaptureStatusChanged(session->getCaptureStatus());
+        }
     });
-    switchToSession(make_unique_object_ptr_as<ICaptureSession, IdleCaptureSession>());
+
+    session_coordinator_->initialize();
 }
 
-CaptureManager::~CaptureManager()
-{
-    cleanup_async_scope(async_scope_);
-}
+CaptureManager::~CaptureManager() = default;
 
 void CaptureManager::triggerButtonPressed(const QString &trigger_id)
 {
-    if (session_->getStatus() == ICaptureSession::Status::Idle)
-    {
-        const auto trigger = trigger_id.toStdString();
-        triggered_by_ = trigger;
-        LOG_DEBUG(logger_capture_manager(), "Got trigger {}", trigger);
-        switchToSession(capture_session_manager_->createFromTrigger(trigger));
-        session_->triggerCapture();
-    }
+    trigger_controller_->triggerButtonPressed(trigger_id);
 }
 
 void CaptureManager::sessionButtonPressed(const QString &session_id)
 {
-    if (session_->getStatus() == ICaptureSession::Status::Idle)
-    {
-        triggered_by_ = "";
-        LOG_DEBUG(logger_capture_manager(), "Got session display trigger {}", session_id.toStdString());
-        switchToSession(capture_session_manager_->createFromSessionId(session_id.toStdString()));
-        session_->triggerCapture();
-    }
+    trigger_controller_->sessionButtonPressed(session_id);
 }
 
 ImageProvider *CaptureManager::createImageProvider() const
@@ -96,7 +84,7 @@ ImageProvider *CaptureManager::createImageProvider() const
 
 Pbox::ICaptureSession *CaptureManager::getSession()
 {
-    return session_.get();
+    return session_coordinator_->getSession();
 }
 
 ICamera *CaptureManager::getCamera()
@@ -106,73 +94,6 @@ ICamera *CaptureManager::getCamera()
 
 void CaptureManager::sessionFinished()
 {
-    LOG_DEBUG(logger_capture_manager(), "Session '{}' finished", session_->sessionId());
     Q_EMIT resetImages();
-    if (session_->sessionId() != IdleCaptureSession::kName)
-    {
-        switchToSession(capture_session_manager_->createIdleSession());
-    }
-}
-
-void CaptureManager::switchToSession(CaptureSessionPtr new_session)
-{
-    const auto old_session_id = session_ != nullptr ? session_->sessionId() : "unknown";
-    session_ = std::move(new_session);
-    if (session_ != nullptr)
-    {
-        connect(session_.get(), &ICaptureSession::requestedImageCapture, camera_.get(), &ICamera::requestCapturePhoto);
-        connect(session_.get(), &ICaptureSession::finished, this, &CaptureManager::sessionFinished);
-        connect(session_.get(), &ICaptureSession::statusChanged, this, &CaptureManager::handleSessionStatusChange);
-        connect(session_.get(),
-                &ICaptureSession::captureStatusChanged,
-                this,
-                &CaptureManager::handleSessionCaptureStatusChange);
-        handleSessionStatusChange();
-        handleSessionCaptureStatusChange();
-    }
-    Q_EMIT sessionChanged();
-    LOG_INFO(logger_capture_manager(),
-             "Switched session from '{}' to '{}'",
-             old_session_id,
-             session_ != nullptr ? session_->sessionId() : "none");
-}
-
-void CaptureManager::handleSessionStatusChange()
-{
-    const auto status = session_->getStatus();
-    if (not triggered_by_.empty())
-    {
-        switch (status)
-        {
-        case ICaptureSession::Status::Idle:
-            trigger_manager_->updateTriggerEffect(triggered_by_, RemoteTrigger::Effect::Idle);
-            break;
-        case ICaptureSession::Status::Capturing:
-            trigger_manager_->updateTriggerEffect(triggered_by_, RemoteTrigger::Effect::Countdown);
-            break;
-        case ICaptureSession::Status::Busy:
-            break;
-        }
-    }
-}
-
-void CaptureManager::handleSessionCaptureStatusChange()
-{
-    const auto status = session_->getCaptureStatus();
-    switch (status)
-    {
-    case ICaptureSession::CaptureStatus::Idle:
-        LOG_DEBUG(logger_capture_manager(), "Camera LED => off");
-        camera_led_->turnOff();
-        break;
-    case ICaptureSession::CaptureStatus::BeforeCapture:
-        LOG_DEBUG(logger_capture_manager(), "Camera LED => Pulsate");
-        camera_led_->playEffect(CameraLed::Effect::Pulsate);
-        break;
-    case ICaptureSession::CaptureStatus::WaitForCapture:
-        LOG_DEBUG(logger_capture_manager(), "Camera LED => Capture");
-        camera_led_->playEffect(CameraLed::Effect::Capture);
-        break;
-    }
 }
 } // namespace Pbox

--- a/Photobox/Core/CaptureManager.hpp
+++ b/Photobox/Core/CaptureManager.hpp
@@ -1,26 +1,29 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Mathis Logemann <mathis.opensource@tuta.io>
+// SPDX-FileCopyrightText: 2024 - 2026 Mathis Logemann <mathis.opensource@tuta.io>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 #include <QObject>
-#include <Pbox/ObjectUniquePtr.hpp>
+#include <memory>
+#include <Pbox/Instance.hpp>
 #include <QtQmlIntegration/qqmlintegration.h>
-#include <exec/async_scope.hpp>
-#include "CaptureSessionManager.hpp"
+#include "CapturePipeline.hpp"
+#include "CaptureSessionCoordinator.hpp"
 #include "ICamera.hpp"
 #include "ICaptureSession.hpp"
 #include "ImageProvider.hpp"
-#include "Pbox/Instance.hpp"
-#include "TriggerManager.hpp"
+#include "SessionEffectController.hpp"
+#include "TriggerController.hpp"
 
 namespace Pbox
 {
-class Scheduler;
-class ImageStorage;
-class CollageContext;
-class RemoteTrigger;
-class CameraLed;
+/**
+ * @brief Facade for capture workflow coordination.
+ *
+ * CaptureManager is the QML-facing entry point for camera capture flows.
+ * It delegates trigger handling, session switching, image capture processing,
+ * and effect management to dedicated helper components.
+ */
 class CaptureManager : public QObject
 {
     Q_OBJECT
@@ -32,16 +35,40 @@ class CaptureManager : public QObject
 
   public:
     PBOX_DISABLE_COPY_MOVE(CaptureManager);
+    /**
+     * @brief Constructs a CaptureManager.
+     * @param scheduler Scheduler used for background work.
+     * @param image_storage Image storage used to persist captured images.
+     * @param camera Camera interface used to request captures.
+     * @param trigger_manager Trigger manager handling remote triggers.
+     * @param camera_led Camera LED controller for capture feedback.
+     * @param capture_session_manager Session manager that creates capture sessions.
+     */
     explicit CaptureManager(Instance<Scheduler> scheduler,
                             Instance<ImageStorage> image_storage,
                             Instance<ICamera> camera,
                             Instance<TriggerManager> trigger_manager,
                             Instance<CameraLed> camera_led,
                             Instance<CaptureSessionManager> capture_session_manager);
+    /**
+     * @brief Destroys the CaptureManager and its helper components.
+     */
     ~CaptureManager() override;
+    /**
+     * @brief Starts capture flow for a trigger button.
+     * @param trigger_id Identifier of the triggered remote.
+     */
     Q_INVOKABLE void triggerButtonPressed(const QString &trigger_id);
+    /**
+     * @brief Starts capture flow for a session button.
+     * @param session_id Identifier of the selected capture session.
+     */
     Q_INVOKABLE void sessionButtonPressed(const QString &session_id);
 
+    /**
+     * @brief Creates a QML image provider for preview images.
+     * @return A newly allocated ImageProvider.
+     */
     ImageProvider *createImageProvider() const;
 
     /// vvv property methods
@@ -53,25 +80,28 @@ class CaptureManager : public QObject
     /// vvv property signals
     void sessionChanged();
     /// ^^^ property signals
+    /**
+     * @brief Emitted when a new image is available for preview.
+     * @param image Captured image.
+     * @param image_id Sequential image identifier.
+     */
     void imageCaptured(const QImage &image, std::uint32_t image_id);
+    /**
+     * @brief Emitted when the current image preview cache should be cleared.
+     */
     void resetImages();
 
   private:
+    /**
+     * @brief Responds to the completion of the current capture session.
+     */
     void sessionFinished();
-    void switchToSession(CaptureSessionPtr new_session);
-    void handleSessionStatusChange();
-    void handleSessionCaptureStatusChange();
 
   private:
-    Instance<Scheduler> scheduler_;
-    Instance<ImageStorage> image_storage_;
-    Instance<ICamera> camera_;
-    Instance<TriggerManager> trigger_manager_;
-    Instance<CameraLed> camera_led_;
-    Instance<CaptureSessionManager> capture_session_manager_;
-    unique_object_ptr<ICaptureSession> session_{nullptr};
-    exec::async_scope async_scope_;
-    std::atomic_uint32_t image_ids_;
-    TriggerId triggered_by_;
+    Instance<ICamera> camera_;                          /**< Camera interface used for live capture requests. */
+    std::unique_ptr<CapturePipeline> capture_pipeline_; /**< Handles image capture and saving pipeline. */
+    std::unique_ptr<CaptureSessionCoordinator> session_coordinator_; /**< Manages capture session lifecycle. */
+    std::unique_ptr<TriggerController> trigger_controller_;          /**< Handles trigger and session button events. */
+    std::unique_ptr<SessionEffectController> session_effect_controller_; /**< Manages LED and trigger effects. */
 };
 } // namespace Pbox

--- a/Photobox/Core/CapturePipeline.cpp
+++ b/Photobox/Core/CapturePipeline.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "CapturePipeline.hpp"
+#include <Pbox/CleanupAsyncScope.hpp>
+#include <Pbox/Logger.hpp>
+
+DEFINE_LOGGER(capture_pipeline);
+
+namespace Pbox
+{
+CapturePipeline::CapturePipeline(Instance<Scheduler> scheduler,
+                                 Instance<ImageStorage> image_storage,
+                                 std::function<ICaptureSession *()> current_session_callback)
+    : scheduler_{std::move(scheduler)}
+    , image_storage_{std::move(image_storage)}
+    , current_session_callback_{std::move(current_session_callback)}
+{}
+
+CapturePipeline::~CapturePipeline()
+{
+    cleanup_async_scope(async_scope_);
+}
+
+void CapturePipeline::onCameraImageCaptured(const QImage &image)
+{
+    const auto image_id = image_ids_++;
+    Q_EMIT imageCaptured(image, image_id);
+
+    if (auto *session = current_session_callback_())
+    {
+        session->imageCaptured(image, image_id);
+    }
+
+    async_scope_.spawn(stdexec::schedule(scheduler_->getWorkScheduler()) |
+                       stdexec::then([image, this]() { return image_storage_->saveImage(image); }) |
+                       stdexec::continues_on(scheduler_->getQtEventLoopScheduler()) |
+                       stdexec::then([this](auto &&saved_image_path) {
+                           if (auto *session = current_session_callback_())
+                           {
+                               session->imageSaved(saved_image_path);
+                           }
+                       }) |
+                       stdexec::upon_error([](auto &&ex_ptr) {
+                           try
+                           {
+                               std::rethrow_exception(ex_ptr);
+                           }
+                           catch (const std::exception &ex)
+                           {
+                               LOG_ERROR(logger_capture_pipeline(), "Error while saving image. {}", ex.what());
+                           }
+                       }));
+}
+} // namespace Pbox

--- a/Photobox/Core/CapturePipeline.hpp
+++ b/Photobox/Core/CapturePipeline.hpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QImage>
+#include <QObject>
+#include <atomic>
+#include <functional>
+#include <Pbox/Instance.hpp>
+#include <exec/async_scope.hpp>
+#include "ICaptureSession.hpp"
+#include "ImageStorage.hpp"
+#include "Scheduler.hpp"
+
+namespace Pbox
+{
+/**
+ * @brief Handles the image capture and persistence pipeline.
+ *
+ * CapturePipeline receives camera images, emits preview signals,
+ * saves images on a background scheduler, and notifies the active session
+ * when image saving completes.
+ */
+class CapturePipeline : public QObject
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * @brief Constructs the capture pipeline.
+     * @param scheduler Scheduler used for async work.
+     * @param image_storage Image storage used to persist captures.
+     * @param current_session_callback Callback returning the active session.
+     * @param parent QObject parent.
+     */
+    explicit CapturePipeline(Instance<Scheduler> scheduler,
+                             Instance<ImageStorage> image_storage,
+                             std::function<ICaptureSession *()> current_session_callback);
+    PBOX_DISABLE_COPY_MOVE(CapturePipeline);
+    /**
+     * @brief Destroys the capture pipeline and cancels pending saves.
+     */
+    ~CapturePipeline() override;
+
+  Q_SIGNALS:
+    /**
+     * @brief Emitted when a new captured image is ready for preview.
+     * @param image Captured image.
+     * @param image_id Sequential image identifier.
+     */
+    void imageCaptured(const QImage &image, std::uint32_t image_id);
+
+  public Q_SLOTS:
+    /**
+     * @brief Handles a new image from the camera.
+     * @param image Captured image.
+     */
+    void onCameraImageCaptured(const QImage &image);
+
+  private:
+    Instance<Scheduler> scheduler_;                               /**< Scheduler for background save tasks. */
+    Instance<ImageStorage> image_storage_;                        /**< Storage backend for captured images. */
+    std::function<ICaptureSession *()> current_session_callback_; /**< Callback to get the active session. */
+    exec::async_scope async_scope_;                               /**< Async scope for pending save operations. */
+    std::atomic_uint32_t image_ids_{0};                           /**< Sequential preview image IDs. */
+};
+} // namespace Pbox

--- a/Photobox/Core/CaptureSessionCoordinator.cpp
+++ b/Photobox/Core/CaptureSessionCoordinator.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file CaptureSessionCoordinator.cpp
+ * @brief Implementation of capture session lifecycle coordination.
+ */
+
+#include "CaptureSessionCoordinator.hpp"
+#include "Pbox/Logger.hpp"
+
+DEFINE_LOGGER(capture_session_coordinator);
+
+namespace Pbox
+{
+CaptureSessionCoordinator::CaptureSessionCoordinator(Instance<ICamera> camera,
+                                                     Instance<CaptureSessionManager> capture_session_manager)
+    : camera_{std::move(camera)}
+    , capture_session_manager_{std::move(capture_session_manager)}
+{}
+
+Pbox::ICaptureSession *CaptureSessionCoordinator::getSession() const
+{
+    return session_.get();
+}
+
+void CaptureSessionCoordinator::initialize()
+{
+    switchToSession(capture_session_manager_->createIdleSession());
+}
+
+void CaptureSessionCoordinator::switchToSession(CaptureSessionPtr new_session)
+{
+    const auto old_session_id = session_ != nullptr ? session_->sessionId() : "unknown";
+    session_ = std::move(new_session);
+
+    if (session_ != nullptr)
+    {
+        connect(session_.get(), &ICaptureSession::requestedImageCapture, camera_.get(), &ICamera::requestCapturePhoto);
+        connect(session_.get(), &ICaptureSession::finished, this, &CaptureSessionCoordinator::sessionFinished);
+        connect(session_.get(),
+                &ICaptureSession::statusChanged,
+                this,
+                &CaptureSessionCoordinator::handleSessionStatusChanged);
+        connect(session_.get(),
+                &ICaptureSession::captureStatusChanged,
+                this,
+                &CaptureSessionCoordinator::handleSessionCaptureStatusChanged);
+
+        handleSessionStatusChanged();
+        handleSessionCaptureStatusChanged();
+    }
+
+    Q_EMIT sessionChanged();
+    LOG_INFO(logger_capture_session_coordinator(),
+             "Switched session from '{}' to '{}',",
+             old_session_id,
+             session_ != nullptr ? session_->sessionId() : "none");
+}
+
+void CaptureSessionCoordinator::sessionFinished()
+{
+    const auto finished_session_id = session_ != nullptr ? session_->sessionId() : "unknown";
+    LOG_DEBUG(logger_capture_session_coordinator(), "Session '{}' finished", finished_session_id);
+    Q_EMIT finished();
+
+    if (session_ != nullptr && session_->sessionId() != IdleCaptureSession::kName)
+    {
+        switchToSession(capture_session_manager_->createIdleSession());
+    }
+}
+
+void CaptureSessionCoordinator::handleSessionStatusChanged()
+{
+    Q_EMIT statusChanged();
+}
+
+void CaptureSessionCoordinator::handleSessionCaptureStatusChanged()
+{
+    Q_EMIT captureStatusChanged();
+}
+} // namespace Pbox

--- a/Photobox/Core/CaptureSessionCoordinator.hpp
+++ b/Photobox/Core/CaptureSessionCoordinator.hpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+#include <QObject>
+#include <Pbox/Instance.hpp>
+#include <Pbox/ObjectUniquePtr.hpp>
+#include "CaptureSessionManager.hpp"
+#include "ICamera.hpp"
+#include "ICaptureSession.hpp"
+#include "IdleCaptureSession.hpp"
+
+namespace Pbox
+{
+/**
+ * @brief Coordinates active capture session lifecycle.
+ *
+ * The CaptureSessionCoordinator owns the currently active session and
+ * forwards session signals to interested consumers.
+ */
+class CaptureSessionCoordinator : public QObject
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * @brief Constructs the session coordinator.
+     * @param camera Camera used to request capture operations.
+     * @param capture_session_manager Manager creating capture sessions.
+     * @param parent QObject parent.
+     */
+    explicit CaptureSessionCoordinator(Instance<ICamera> camera,
+                                       Instance<CaptureSessionManager> capture_session_manager);
+    PBOX_DISABLE_COPY_MOVE(CaptureSessionCoordinator);
+    ~CaptureSessionCoordinator() override = default;
+
+    /**
+     * @brief Returns the currently active session.
+     * @return Pointer to the current session or nullptr.
+     */
+    Pbox::ICaptureSession *getSession() const;
+
+    /**
+     * @brief Initializes the coordinator with an idle session.
+     */
+    void initialize();
+
+    /**
+     * @brief Switches the active session.
+     * @param new_session The new session to activate.
+     */
+    void switchToSession(CaptureSessionPtr new_session);
+
+  Q_SIGNALS:
+    /**
+     * @brief Emitted when the active session finishes.
+     */
+    void finished();
+    /**
+     * @brief Emitted when the active session changes.
+     */
+    void sessionChanged();
+    /**
+     * @brief Emitted when the active session status changes.
+     */
+    void statusChanged();
+    /**
+     * @brief Emitted when the active session capture status changes.
+     */
+    void captureStatusChanged();
+
+  private Q_SLOTS:
+    /**
+     * @brief Internal slot for session finished handling.
+     */
+    void sessionFinished();
+    /**
+     * @brief Internal slot for session status updates.
+     */
+    void handleSessionStatusChanged();
+    /**
+     * @brief Internal slot for capture status updates.
+     */
+    void handleSessionCaptureStatusChanged();
+
+  private:
+    Instance<ICamera> camera_;                                /**< Camera interface used by the session. */
+    Instance<CaptureSessionManager> capture_session_manager_; /**< Session factory provider. */
+    unique_object_ptr<ICaptureSession> session_{nullptr};     /**< Current active capture session. */
+};
+} // namespace Pbox

--- a/Photobox/Core/CaptureSessionManager.hpp
+++ b/Photobox/Core/CaptureSessionManager.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 #include <QtQmlIntegration/qqmlintegration.h>
 #include "CaptureSessionFactory.hpp"

--- a/Photobox/Core/SessionEffectController.cpp
+++ b/Photobox/Core/SessionEffectController.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "SessionEffectController.hpp"
+
+namespace Pbox
+{
+SessionEffectController::SessionEffectController(Instance<TriggerManager> trigger_manager,
+                                                 Instance<CameraLed> camera_led,
+                                                 std::function<const TriggerId &()> triggered_by_callback)
+    : trigger_manager_{std::move(trigger_manager)}
+    , camera_led_{std::move(camera_led)}
+    , triggered_by_callback_{std::move(triggered_by_callback)}
+{}
+
+void SessionEffectController::handleSessionStatusChanged(ICaptureSession::Status status)
+{
+    const auto &triggered_by = triggered_by_callback_();
+    if (triggered_by.empty())
+    {
+        return;
+    }
+
+    switch (status)
+    {
+    case ICaptureSession::Status::Idle:
+        trigger_manager_->updateTriggerEffect(triggered_by, RemoteTrigger::Effect::Idle);
+        break;
+    case ICaptureSession::Status::Capturing:
+        trigger_manager_->updateTriggerEffect(triggered_by, RemoteTrigger::Effect::Countdown);
+        break;
+    case ICaptureSession::Status::Busy:
+        break;
+    }
+}
+
+void SessionEffectController::handleSessionCaptureStatusChanged(ICaptureSession::CaptureStatus capture_status)
+{
+    switch (capture_status)
+    {
+    case ICaptureSession::CaptureStatus::Idle:
+        camera_led_->turnOff();
+        break;
+    case ICaptureSession::CaptureStatus::BeforeCapture:
+        camera_led_->playEffect(CameraLed::Effect::Pulsate);
+        break;
+    case ICaptureSession::CaptureStatus::WaitForCapture:
+        camera_led_->playEffect(CameraLed::Effect::Capture);
+        break;
+    }
+}
+} // namespace Pbox

--- a/Photobox/Core/SessionEffectController.hpp
+++ b/Photobox/Core/SessionEffectController.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <functional>
+#include <Pbox/Instance.hpp>
+#include "CameraLed.hpp"
+#include "ICaptureSession.hpp"
+#include "TriggerId.hpp"
+#include "TriggerManager.hpp"
+
+namespace Pbox
+{
+/**
+ * @brief Maps capture session state changes to visual effects.
+ *
+ * SessionEffectController applies LED effects and updates remote trigger status
+ * based on the active session lifecycle.
+ */
+class SessionEffectController
+{
+  public:
+    /**
+     * @brief Constructs the session effect controller.
+     * @param trigger_manager Trigger manager used for effect updates.
+     * @param camera_led Camera LED controller used for visual feedback.
+     * @param triggered_by_callback Callback returning the active trigger ID.
+     */
+    SessionEffectController(Instance<TriggerManager> trigger_manager,
+                            Instance<CameraLed> camera_led,
+                            std::function<const TriggerId &()> triggered_by_callback);
+    PBOX_DISABLE_COPY_MOVE(SessionEffectController);
+    ~SessionEffectController() = default;
+
+    /**
+     * @brief Handles a session status update.
+     * @param status Current session status.
+     */
+    void handleSessionStatusChanged(ICaptureSession::Status status);
+    /**
+     * @brief Handles a capture status update.
+     * @param capture_status Current capture status.
+     */
+    void handleSessionCaptureStatusChanged(ICaptureSession::CaptureStatus capture_status);
+
+  private:
+    Instance<TriggerManager> trigger_manager_;                 /**< Trigger manager for remote effects. */
+    Instance<CameraLed> camera_led_;                           /**< Camera LED controller. */
+    std::function<const TriggerId &()> triggered_by_callback_; /**< Returns the active trigger ID. */
+};
+} // namespace Pbox

--- a/Photobox/Core/TriggerController.cpp
+++ b/Photobox/Core/TriggerController.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "TriggerController.hpp"
+#include <Pbox/Logger.hpp>
+
+DEFINE_LOGGER(trigger_controller);
+
+namespace Pbox
+{
+TriggerController::TriggerController(Instance<TriggerManager> trigger_manager,
+                                     Instance<CaptureSessionManager> capture_session_manager,
+                                     std::function<ICaptureSession *()> get_current_session_callback,
+                                     std::function<void(CaptureSessionPtr)> switch_session_callback,
+                                     QObject *parent)
+    : QObject(parent)
+    , get_current_session_callback_{std::move(get_current_session_callback)}
+    , switch_session_callback_{std::move(switch_session_callback)}
+    , trigger_manager_{std::move(trigger_manager)}
+    , capture_session_manager_{std::move(capture_session_manager)}
+{
+    connect(trigger_manager_.get(), &TriggerManager::triggerFired, this, &TriggerController::handleTriggerFired);
+}
+
+bool TriggerController::canSwitchSession() const
+{
+    if (auto *session = get_current_session_callback_())
+    {
+        return session->getStatus() == ICaptureSession::Status::Idle;
+    }
+    return false;
+}
+
+void TriggerController::triggerButtonPressed(const QString &trigger_id)
+{
+    if (not canSwitchSession())
+    {
+        return;
+    }
+
+    const auto trigger = trigger_id.toStdString();
+    triggered_by_ = trigger;
+    LOG_DEBUG(logger_trigger_controller(), "Got trigger {}", trigger);
+    switch_session_callback_(capture_session_manager_->createFromTrigger(trigger));
+
+    if (auto *session = get_current_session_callback_())
+    {
+        session->triggerCapture();
+    }
+}
+
+void TriggerController::sessionButtonPressed(const QString &session_id)
+{
+    if (not canSwitchSession())
+    {
+        return;
+    }
+
+    triggered_by_.clear();
+    LOG_DEBUG(logger_trigger_controller(), "Got session display trigger {}", session_id.toStdString());
+    switch_session_callback_(capture_session_manager_->createFromSessionId(session_id.toStdString()));
+
+    if (auto *session = get_current_session_callback_())
+    {
+        session->triggerCapture();
+    }
+}
+
+void TriggerController::handleTriggerFired(const TriggerId &trigger_id)
+{
+    triggerButtonPressed(QString::fromStdString(trigger_id));
+}
+
+const TriggerId &TriggerController::getTriggeredBy() const
+{
+    return triggered_by_;
+}
+} // namespace Pbox

--- a/Photobox/Core/TriggerController.hpp
+++ b/Photobox/Core/TriggerController.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Mathis Logemann <mathis.opensource@tuta.io>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+#include <QObject>
+#include <functional>
+#include <Pbox/Instance.hpp>
+#include "CaptureSessionManager.hpp"
+#include "ICaptureSession.hpp"
+#include "TriggerId.hpp"
+#include "TriggerManager.hpp"
+
+namespace Pbox
+{
+/**
+ * @brief Handles trigger and session button events.
+ *
+ * TriggerController decides when a session may start and requests the
+ * appropriate capture session from the session manager.
+ */
+class TriggerController : public QObject
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * @brief Constructs the trigger controller.
+     * @param trigger_manager Trigger manager handling remote input.
+     * @param capture_session_manager Manager to create sessions from IDs or triggers.
+     * @param get_current_session_callback Callback to inspect the active session.
+     * @param switch_session_callback Callback to activate a new session.
+     * @param parent QObject parent.
+     */
+    TriggerController(Instance<TriggerManager> trigger_manager,
+                      Instance<CaptureSessionManager> capture_session_manager,
+                      std::function<ICaptureSession *()> get_current_session_callback,
+                      std::function<void(CaptureSessionPtr)> switch_session_callback,
+                      QObject *parent = nullptr);
+    PBOX_DISABLE_COPY_MOVE(TriggerController);
+    ~TriggerController() override = default;
+
+    /**
+     * @brief Invoked when a remote trigger button is pressed.
+     * @param trigger_id Trigger identifier.
+     */
+    void triggerButtonPressed(const QString &trigger_id);
+    /**
+     * @brief Invoked when a session button is pressed.
+     * @param session_id Session identifier.
+     */
+    void sessionButtonPressed(const QString &session_id);
+    /**
+     * @brief Gets the ID of the last trigger that initiated the current session.
+     * @return Trigger identifier or empty if none.
+     */
+    const TriggerId &getTriggeredBy() const;
+
+  private Q_SLOTS:
+    /**
+     * @brief Slot called when a remote trigger fires.
+     * @param trigger_id Trigger identifier.
+     */
+    void handleTriggerFired(const TriggerId &trigger_id);
+
+  private:
+    bool canSwitchSession() const;
+
+    std::function<ICaptureSession *()> get_current_session_callback_; /**< Active session query callback. */
+    std::function<void(CaptureSessionPtr)> switch_session_callback_;  /**< Session activation callback. */
+    Instance<TriggerManager> trigger_manager_;                        /**< Remote trigger manager. */
+    Instance<CaptureSessionManager> capture_session_manager_;         /**< Session factory provider. */
+    TriggerId triggered_by_;                                          /**< Currently active trigger ID. */
+};
+} // namespace Pbox


### PR DESCRIPTION
The CaptureManager had a bunch of responsibilities. Now it's split up into different segments and just acts as a facade for the UI